### PR TITLE
Allow multiple checkstyle-result* files

### DIFF
--- a/test/vars/defaultResultsStage/DefaultResultsStageIT.groovy
+++ b/test/vars/defaultResultsStage/DefaultResultsStageIT.groovy
@@ -97,7 +97,7 @@ class DefaultResultsStageIT extends PVLibraryIntegrationTestBase {
       canComputeNew  : false,
       defaultEncoding: '',
       healthy        : '',
-      pattern        : '**/target/checkstyle-result.xml',
+      pattern        : '**/target/checkstyle-result*.xml',
       unHealthy      : ''
     ]
     Map expectedAnalysisPublisherCall = [

--- a/vars/defaultResultsStage.groovy
+++ b/vars/defaultResultsStage.groovy
@@ -242,7 +242,7 @@ void _checkStyle(Map config = [:]) {
     canComputeNew: false,
     defaultEncoding: '',
     healthy: '',
-    pattern: '**/target/checkstyle-result.xml',
+    pattern: '**/target/checkstyle-result*.xml',
     unHealthy: ''
   )
   currentBuildResult = currentBuild.result


### PR DESCRIPTION
There are some use-cases, where multiple maven plugins produce checkstyle compatible output (e.g. when using both checkstyle and ktlint).
Currently the pattern does not allow the usage of multiple files (ok, it does, if you place them in `/target/target/checkstyle-result.xml` or `/target/foo/target/checkstyle-result.xml`), therefor I'd suggest this minor change to allow `checkstyle-result.xml` and `checkstyle-result-ktlint.xml` 