### PR TITLE
Release 2.0.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "submodules/jenkins-pipeline-library/master"]
-	path = submodules/jenkins-pipeline-library/master
-	url = https://github.com/wcm-io-devops/jenkins-pipeline-library.git

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>de.pro-vision.devops.jenkins</groupId>
   <artifactId>de.pro-vision.devops.jenkins.pv-pipeline-library</artifactId>
-  <version>1.5.1-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
 
   <scm>
     <connection>scm:git:git@github.com:pro-vision/jenkins-pv-pipeline-library.git</connection>
@@ -68,12 +68,12 @@
     <dependency>
       <groupId>io.wcm.devops.jenkins</groupId>
       <artifactId>io.wcm.devops.jenkins.pipeline-library</artifactId>
-      <version>1.9.1-SNAPSHOT</version>
+      <version>2.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.wcm.devops.jenkins</groupId>
       <artifactId>io.wcm.devops.jenkins.pipeline-library</artifactId>
-      <version>1.9.1-SNAPSHOT</version>
+      <version>2.0.0-SNAPSHOT</version>
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
@@ -208,6 +208,32 @@
     <sourceDirectory>${project.basedir}/src</sourceDirectory>
     <testSourceDirectory>${project.basedir}/test</testSourceDirectory>
     <plugins>
+      <!-- Extract jenkins-pipeline-library sources -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-jenkine-pipeline-library</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>io.wcm.devops.jenkins</groupId>
+                  <artifactId>io.wcm.devops.jenkins.pipeline-library</artifactId>
+                  <classifier>complete</classifier>
+                  <type>zip</type>
+                  <outputDirectory>${project.build.directory}/jenkins-pipeline-library</outputDirectory>
+                  <includes>**/*</includes>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <!-- license check -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/test/de/provision/devops/testing/jenkins/pipeline/PVLibraryIntegrationTestBase.groovy
+++ b/test/de/provision/devops/testing/jenkins/pipeline/PVLibraryIntegrationTestBase.groovy
@@ -21,6 +21,7 @@ package de.provision.devops.testing.jenkins.pipeline
 
 import io.wcm.testing.jenkins.pipeline.LibraryIntegrationTestBase
 import io.wcm.testing.jenkins.pipeline.LibraryIntegrationTestContext
+import io.wcm.testing.jenkins.pipeline.global.lib.SelfSourceRetriever
 import io.wcm.testing.jenkins.pipeline.global.lib.SubmoduleSourceRetriever
 import org.jenkinsci.plugins.pipeline.utility.steps.fs.FileWrapper
 
@@ -51,10 +52,10 @@ class PVLibraryIntegrationTestBase extends LibraryIntegrationTestBase {
     // redirect tool step to own callback
     helper.registerAllowedMethod(TOOL, [String.class], toolCallback)
 
-    // load the pipeline-library from git submodule
+    // load the pipeline-library from extracted folder in pipeline-library
     def library = library()
       .name('pipeline-library')
-      .retriever(SubmoduleSourceRetriever.submoduleSourceRetriever(("submodules")))
+      .retriever(SelfSourceRetriever.localSourceRetriever("target/jenkins-pipeline-library"))
       .targetPath('jenkins-pipeline-library')
       .defaultVersion("master")
       .allowOverride(true)

--- a/test/de/provision/devops/testing/jenkins/pipeline/PVLibraryIntegrationTestBase.groovy
+++ b/test/de/provision/devops/testing/jenkins/pipeline/PVLibraryIntegrationTestBase.groovy
@@ -70,13 +70,13 @@ class PVLibraryIntegrationTestBase extends LibraryIntegrationTestBase {
   protected void afterLoadingScript() {
     super.afterLoadingScript()
     helper.registerAllowedMethod(EXEC_MANAGED_SHELL_SCRIPT, [String.class, String.class], { String fileId, String argLine ->
-      stepRecorder.record(EXEC_MANAGED_SHELL_SCRIPT, [fileId: fileId, args: argLine])
+      this.context.getStepRecorder().record(EXEC_MANAGED_SHELL_SCRIPT, [fileId: fileId, args: argLine])
     })
     helper.registerAllowedMethod(EXEC_MANAGED_SHELL_SCRIPT, [String.class, List.class], { String fileId, List args ->
-      stepRecorder.record(EXEC_MANAGED_SHELL_SCRIPT, [fileId: fileId, args: args])
+      this.context.getStepRecorder().record(EXEC_MANAGED_SHELL_SCRIPT, [fileId: fileId, args: args])
     })
     helper.registerAllowedMethod(MAVEN_PURGE_SNAPSHOTS, [Map.class], { Map config ->
-      stepRecorder.record(MAVEN_PURGE_SNAPSHOTS, config)
+      this.context.getStepRecorder().record(MAVEN_PURGE_SNAPSHOTS, config)
     }
     )
   }
@@ -87,7 +87,7 @@ class PVLibraryIntegrationTestBase extends LibraryIntegrationTestBase {
    * @return mocked tool path
    */
   def toolCallback = { String tool ->
-    stepRecorder.record(TOOL, tool)
+    this.context.getStepRecorder().record(TOOL, tool)
     if (tool.matches(/(?i).*maven.*/)) {
       return LibraryIntegrationTestContext.TOOL_MAVEN_PREFIX.concat(tool)
     }

--- a/test/de/provision/devops/testing/jenkins/pipeline/PVLibraryIntegrationTestBase.groovy
+++ b/test/de/provision/devops/testing/jenkins/pipeline/PVLibraryIntegrationTestBase.groovy
@@ -25,7 +25,7 @@ import io.wcm.testing.jenkins.pipeline.global.lib.SubmoduleSourceRetriever
 import org.jenkinsci.plugins.pipeline.utility.steps.fs.FileWrapper
 
 import static com.lesfurets.jenkins.unit.global.lib.LibraryConfiguration.library
-import static io.wcm.testing.jenkins.pipeline.StepConstants.EXEC_MANAGED_SHELL_SCRIPT
+import static io.wcm.testing.jenkins.pipeline.StepConstants.MANAGED_SCRIPTS_EXEC_JENKINS_SHELL_SCRIPT
 import static io.wcm.testing.jenkins.pipeline.StepConstants.FIND_FILES
 import static io.wcm.testing.jenkins.pipeline.StepConstants.MAVEN_PURGE_SNAPSHOTS
 import static io.wcm.testing.jenkins.pipeline.StepConstants.TOOL
@@ -69,11 +69,11 @@ class PVLibraryIntegrationTestBase extends LibraryIntegrationTestBase {
   @Override
   protected void afterLoadingScript() {
     super.afterLoadingScript()
-    helper.registerAllowedMethod(EXEC_MANAGED_SHELL_SCRIPT, [String.class, String.class], { String fileId, String argLine ->
-      this.context.getStepRecorder().record(EXEC_MANAGED_SHELL_SCRIPT, [fileId: fileId, args: argLine])
+    helper.registerAllowedMethod(MANAGED_SCRIPTS_EXEC_JENKINS_SHELL_SCRIPT, [String.class, String.class], { String fileId, String argLine ->
+      this.context.getStepRecorder().record(MANAGED_SCRIPTS_EXEC_JENKINS_SHELL_SCRIPT, [fileId: fileId, args: argLine])
     })
-    helper.registerAllowedMethod(EXEC_MANAGED_SHELL_SCRIPT, [String.class, List.class], { String fileId, List args ->
-      this.context.getStepRecorder().record(EXEC_MANAGED_SHELL_SCRIPT, [fileId: fileId, args: args])
+    helper.registerAllowedMethod(MANAGED_SCRIPTS_EXEC_JENKINS_SHELL_SCRIPT, [String.class, List.class], { String fileId, List args ->
+      this.context.getStepRecorder().record(MANAGED_SCRIPTS_EXEC_JENKINS_SHELL_SCRIPT, [fileId: fileId, args: args])
     })
     helper.registerAllowedMethod(MAVEN_PURGE_SNAPSHOTS, [Map.class], { Map config ->
       this.context.getStepRecorder().record(MAVEN_PURGE_SNAPSHOTS, config)

--- a/test/vars/buildDefault/BuildDefaultIT.groovy
+++ b/test/vars/buildDefault/BuildDefaultIT.groovy
@@ -120,8 +120,6 @@ class BuildDefaultIT extends PVLibraryIntegrationTestBase {
   }
 
   void assertDefaults() {
-    Map steps = stepRecorder.recordedSteps
-
 
     // trigger assertions
     String pollScmCall = assertOnce(POLLSCM)
@@ -210,8 +208,6 @@ class BuildDefaultIT extends PVLibraryIntegrationTestBase {
     assertNone(CRON)
     assertNone(UPSTREAM)
 
-    Map steps = this.stepRecorder.getRecordedSteps()
-
     // color wrapping
     assertOnce(ANSI_COLOR)
 
@@ -256,16 +252,16 @@ class BuildDefaultIT extends PVLibraryIntegrationTestBase {
   protected void afterLoadingScript() {
     super.afterLoadingScript()
     helper.registerAllowedMethod(PURGE_SNAPSHOTS_FROM_REPOSITORY, [], {
-      stepRecorder.record(PURGE_SNAPSHOTS_FROM_REPOSITORY, null)
+      this.context.getStepRecorder().record(PURGE_SNAPSHOTS_FROM_REPOSITORY, null)
     })
     // mock gitTools.getParentBranch call
     helper.registerAllowedMethod("getParentBranch", [], { Closure closure ->
-      stepRecorder.record("getParentBranch", null)
+      this.context.getStepRecorder().record("getParentBranch", null)
       return "origin/develop"
     })
 
     helper.registerAllowedMethod(NODE, [String.class, Closure.class], { String agent, Closure closure ->
-      stepRecorder.record(NODE, agent)
+      this.context.getStepRecorder().record(NODE, agent)
       // execute the closure
       closure.call()
     })

--- a/test/vars/buildFeature/BuildFeatureIT.groovy
+++ b/test/vars/buildFeature/BuildFeatureIT.groovy
@@ -129,10 +129,10 @@ class BuildFeatureIT extends PVLibraryIntegrationTestBase {
     // catch buildDefault step calls
     this.helper.registerAllowedMethod(PVStepConstants.BUILD_DEFAULT, [Map.class], {
       config ->
-        this.stepRecorder.record(PVStepConstants.BUILD_DEFAULT, config)
+        this.context.getStepRecorder().record(PVStepConstants.BUILD_DEFAULT, config)
     })
     this.helper.registerAllowedMethod(PVStepConstants.BUILD_DEFAULT, [], {
-      this.stepRecorder.record(PVStepConstants.BUILD_DEFAULT, null)
+      this.context.getStepRecorder().record(PVStepConstants.BUILD_DEFAULT, null)
     })
   }
 

--- a/test/vars/defaultBuildWrapper/DefaultBuildWrapperIT.groovy
+++ b/test/vars/defaultBuildWrapper/DefaultBuildWrapperIT.groovy
@@ -84,16 +84,16 @@ class DefaultBuildWrapperIT extends PVLibraryIntegrationTestBase {
 
     // mock notify calls
     helper.registerAllowedMethod("mail", [Map.class], { Map config ->
-      stepRecorder.record("mail", config)
+      this.context.getStepRecorder().record("mail", config)
     })
     helper.registerAllowedMethod("mattermost", [Map.class], { Map config ->
-      stepRecorder.record("mattermost", config)
+      this.context.getStepRecorder().record("mattermost", config)
     })
     helper.registerAllowedMethod("mqtt", [Map.class], { Map config ->
-      stepRecorder.record("mqtt", config)
+      this.context.getStepRecorder().record("mqtt", config)
     })
     helper.registerAllowedMethod("teams", [Map.class], { Map config ->
-      stepRecorder.record("teams", config)
+      this.context.getStepRecorder().record("teams", config)
     })
   }
 }

--- a/test/vars/defaultPreparationStage/DefaultPreparationStageIT.groovy
+++ b/test/vars/defaultPreparationStage/DefaultPreparationStageIT.groovy
@@ -168,10 +168,10 @@ class DefaultPreparationStageIT extends PVLibraryIntegrationTestBase {
   protected void afterLoadingScript() {
     super.afterLoadingScript()
     helper.registerAllowedMethod(PURGE_SNAPSHOTS_FROM_REPOSITORY, [], {
-      stepRecorder.record(PURGE_SNAPSHOTS_FROM_REPOSITORY, null)
+      this.context.getStepRecorder().record(PURGE_SNAPSHOTS_FROM_REPOSITORY, null)
     })
     helper.registerAllowedMethod(SET_BUILD_NAME, [], {
-      stepRecorder.record(SET_BUILD_NAME, null)
+      this.context.getStepRecorder().record(SET_BUILD_NAME, null)
     })
   }
 }

--- a/test/vars/featureBranchPreparationStage/FeatureBranchPreparationStageIT.groovy
+++ b/test/vars/featureBranchPreparationStage/FeatureBranchPreparationStageIT.groovy
@@ -102,7 +102,7 @@ class FeatureBranchPreparationStageIT extends PVLibraryIntegrationTestBase {
 
     // mock gitTools.getParentBranch call
     helper.registerAllowedMethod("getParentBranch", [], { Closure closure ->
-      stepRecorder.record("getParentBranch", null)
+      this.context.getStepRecorder().record("getParentBranch", null)
       return mockedParentBranch
     })
   }

--- a/test/vars/routeDefaultJenkinsFile/RouteDefaultJenkinsFileIT.groovy
+++ b/test/vars/routeDefaultJenkinsFile/RouteDefaultJenkinsFileIT.groovy
@@ -51,7 +51,6 @@ class RouteDefaultJenkinsFileIT extends PVLibraryIntegrationTestBase {
   void shouldCallDefaultFeatureStep() {
     super.binding.setVariable('scm', true)
     this.setEnv(EnvironmentConstants.BRANCH_NAME, "feature/i-am-correct")
-    this.runWrapper = new RunWrapperMock(null)
     this.binding.setVariable("currentBuild", this.context.getRunWrapperMock())
     loadAndExecuteScript("vars/routeDefaultJenkinsFile/jobs/routeDefaultJenkinsFileJob.groovy")
     assertOnce(PVStepConstants.BUILD_FEATURE)

--- a/test/vars/routeDefaultJenkinsFile/RouteDefaultJenkinsFileIT.groovy
+++ b/test/vars/routeDefaultJenkinsFile/RouteDefaultJenkinsFileIT.groovy
@@ -22,9 +22,9 @@ package vars.routeDefaultJenkinsFile
 import de.provision.devops.testing.jenkins.pipeline.PVLibraryIntegrationTestBase
 import de.provision.devops.testing.jenkins.pipeline.PVStepConstants
 import hudson.AbortException
+import io.wcm.devops.jenkins.pipeline.environment.EnvironmentConstants
 import io.wcm.testing.jenkins.pipeline.RunWrapperMock
 import io.wcm.testing.jenkins.pipeline.StepConstants
-import io.wcm.devops.jenkins.pipeline.environment.EnvironmentConstants
 import org.junit.Test
 
 import static io.wcm.testing.jenkins.pipeline.recorder.StepRecorderAssert.assertNone
@@ -73,18 +73,18 @@ class RouteDefaultJenkinsFileIT extends PVLibraryIntegrationTestBase {
     // catch buildFeature calls
     this.helper.registerAllowedMethod(PVStepConstants.BUILD_FEATURE, [Map.class], {
       config ->
-        this.stepRecorder.record(PVStepConstants.BUILD_FEATURE, config)
+        this.context.getStepRecorder().record(PVStepConstants.BUILD_FEATURE, config)
     })
     this.helper.registerAllowedMethod(PVStepConstants.BUILD_FEATURE, [], {
-      this.stepRecorder.record(PVStepConstants.BUILD_FEATURE, null)
+      this.context.getStepRecorder().record(PVStepConstants.BUILD_FEATURE, null)
     })
 
     this.helper.registerAllowedMethod(PVStepConstants.BUILD_DEFAULT, [Map.class], {
       config ->
-        this.stepRecorder.record(PVStepConstants.BUILD_DEFAULT, config)
+        this.context.getStepRecorder().record(PVStepConstants.BUILD_DEFAULT, config)
     })
     this.helper.registerAllowedMethod(PVStepConstants.BUILD_DEFAULT, [], {
-      this.stepRecorder.record(PVStepConstants.BUILD_DEFAULT, null)
+      this.context.getStepRecorder().record(PVStepConstants.BUILD_DEFAULT, null)
     })
   }
 }

--- a/test/vars/routeDefaultJenkinsFile/RouteDefaultJenkinsFileIT.groovy
+++ b/test/vars/routeDefaultJenkinsFile/RouteDefaultJenkinsFileIT.groovy
@@ -52,7 +52,7 @@ class RouteDefaultJenkinsFileIT extends PVLibraryIntegrationTestBase {
     super.binding.setVariable('scm', true)
     this.setEnv(EnvironmentConstants.BRANCH_NAME, "feature/i-am-correct")
     this.runWrapper = new RunWrapperMock(null)
-    this.binding.setVariable("currentBuild", runWrapper)
+    this.binding.setVariable("currentBuild", this.context.getRunWrapperMock())
     loadAndExecuteScript("vars/routeDefaultJenkinsFile/jobs/routeDefaultJenkinsFileJob.groovy")
     assertOnce(PVStepConstants.BUILD_FEATURE)
     assertNone(PVStepConstants.BUILD_DEFAULT)

--- a/vars/defaultAnalyzeStage.md
+++ b/vars/defaultAnalyzeStage.md
@@ -19,7 +19,7 @@ auto lookup mechanism.
 * [Extension options](#extension-options)
 * [Configuration options](#configuration-options)
     * [`_extend`](#_extend-optional)
-    * [`enabled`](enabled-optional)
+    * [`enabled`](#enabled-optional)
     * [`maven`](#maven-optional)
     * [`stash`](#stash-optional)
 * [Related classes](#related-classes)


### PR DESCRIPTION
Update to jenkins-pipeline-library 2.0.0(-SNAPSHOT)
Remove deprecated steps, classes, properties etc.